### PR TITLE
Fix scikit-learn compatibility issues and update dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ def page_2():
                                 token_pattern="[a-zA-Z][a-zA-Z]+")  # at least two letters, and no numerical or special characters
             dtm = cv.fit_transform(st.session_state.corpus)
             progress.progress(1.0)
-            wordlist = cv.get_feature_names()
+            wordlist = cv.get_feature_names_out()
             docfreqs = list(np.squeeze(np.asarray((dtm != 0).sum(0))))  # count number of non-zero document occurrences for each row (i.e. each word)
             countsDF = pd.DataFrame(zip(wordlist, docfreqs)).reset_index()
             countsDF.columns = ["id", "word", "DF"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-scikit-learn==1.0.2
+scikit-learn>=1.0.2
 nltk
 networkx
 pyvis
-numpy==1.21.5
+numpy>=1.21.5
+pandas


### PR DESCRIPTION
- Replace deprecated get_feature_names() with get_feature_names_out()
- Update scikit-learn and numpy to use minimum version constraints
- Add missing pandas dependency to requirements.txt

These changes resolve compatibility issues with modern Python environments and scikit-learn versions 1.0+.

The deprecated get_feature_names() method was removed in scikit-learn 1.0 and replaced with get_feature_names_out(). The strict version pins were also causing issues with modern Python installations.

Tested with Python 3.10 and scikit-learn 1.7.2.